### PR TITLE
Update README and add logging module

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Sample environment configuration
+# Copy to .env and update values as needed
+AWS_REGION=eu-west-2
+STAGE=dev
+THUMBNAIL_WIDTH=150
+THUMBNAIL_HEIGHT=150
+THUMBNAIL_QUALITY=80
+# Values populated by src/cognito_build.sh
+COGNITO_USER_POOL_ID=
+COGNITO_CLIENT_ID=
+AWS_PROFILE=default

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "graphql": "^16.9.0",
     "graphql-tag": "^2.12.6",
     "sharp": "^0.32.6",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "winston": "^3.9.0"
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",

--- a/readme.md
+++ b/readme.md
@@ -1,26 +1,5 @@
 # Welcome to hopo-middleware Read Me
 
-
-
-
-##### NPM Installs for the above packages
-```javascript
-npm install axios
-npm install axios-retry
-npm install dotenv
-npm install @aws-sdk/util-dynamodb
-npm install uuid
-npm install @aws-sdk/client-dynamodb
-npm install --save-dev jsdoc
-```
-##### Or as a single command
-```javascript
-npm install axios axios-retry dotenv @aws-sdk/util-dynamodb uuid @aws-sdk/client-dynamodb --save-dev jsdoc
-```
-
-
-
-
 #### SDLC:
 
 ###### Data Structure:
@@ -210,9 +189,15 @@ npm install
 
 Set environment variables:
 
-Create and edit `.env`
-```console
+A `.env.example` file is included. Copy it and update values before deployment.
+```bash
 cp .env.example .env
+```
+
+Run the Cognito setup script to create the user pool and client. The script will
+append the generated IDs to your `.env` file.
+```bash
+bash src/cognito_build.sh
 ```
 
 Deploy to AWS on the specified stage:
@@ -228,3 +213,9 @@ Destroy the AWS resources on the specified stage:
 ```bash
 bash destroy.sh
 ```
+
+## Logging
+
+Application logs are handled using the Winston logger. Import the configured
+logger from `src/utils/logger.js` in your functions to record structured log
+messages.

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,0 +1,14 @@
+import winston from 'winston';
+
+const logger = winston.createLogger({
+  level: 'info',
+  format: winston.format.json(),
+  transports: [
+    new winston.transports.Console({
+      format: winston.format.simple()
+    })
+  ]
+});
+
+export default logger;
+


### PR DESCRIPTION
## Summary
- remove axios and dotenv install instructions
- add guidance for `.env.example`
- document Cognito build script
- document Winston logger usage
- add sample `.env.example`
- add Winston dependency and logger utility

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844b620ff3c8327adb86f358e1d3881