### PR TITLE
Add Winston logger utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "graphql": "^16.9.0",
     "graphql-tag": "^2.12.6",
     "sharp": "^0.32.6",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "winston": "^3.10.0"
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",

--- a/src/utils/image-processor.js
+++ b/src/utils/image-processor.js
@@ -1,5 +1,6 @@
 import AWS from 'aws-sdk';
 import sharp from 'sharp';
+import logger from './logger';
 
 const s3 = new AWS.S3();
 const dynamoDB = new AWS.DynamoDB.DocumentClient();
@@ -66,7 +67,7 @@ export const handler = async (event) => {
       body: JSON.stringify({ message: 'Images processed successfully' })
     };
   } catch (error) {
-    console.error('Error processing image:', error);
+    logger.error('Error processing image:', error);
     throw error;
   }
 };

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,0 +1,16 @@
+import winston from 'winston';
+
+const { combine, timestamp, printf } = winston.format;
+
+const level = process.env.LOG_LEVEL || 'info';
+
+const logger = winston.createLogger({
+  level,
+  format: combine(
+    timestamp(),
+    printf(({ level, message, timestamp }) => `${timestamp} ${level}: ${message}`)
+  ),
+  transports: [new winston.transports.Console()]
+});
+
+export default logger;


### PR DESCRIPTION
## Summary
- add `winston` dependency
- create a reusable logger utility
- use the logger inside the image processor

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844b61e20588327a849a07b4384dcc9