### PR TITLE
Align DynamoDB table names with environment variable

### DIFF
--- a/src/resources/dynamodb-config.yml
+++ b/src/resources/dynamodb-config.yml
@@ -2,7 +2,7 @@ Resources:
   DynamodbTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: "DynamodbTable-${self:provider.stage}"
+      TableName: "${self:service}-${self:provider.stage}"
       AttributeDefinitions:
         - AttributeName: PK
           AttributeType: S


### PR DESCRIPTION
## Summary
- use `${self:service}-${self:provider.stage}` for the DynamoDB `TableName`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844b61c65408327afeb12eadfc2af22