### PR TITLE
Consolidate AppSync resolvers

### DIFF
--- a/src/resolvers/resolvers.js
+++ b/src/resolvers/resolvers.js
@@ -1,0 +1,282 @@
+import { util } from '@aws-appsync/utils';
+
+export function request(ctx) {
+  const field = ctx.info.fieldName;
+  const args = ctx.args || {};
+  const sub = ctx.identity.sub;
+
+  switch (field) {
+    // Dwelling operations
+    case 'getDwelling':
+      return {
+        operation: 'GetItem',
+        key: util.dynamodb.toMapValues({
+          PK: `SUB#${sub}`,
+          SK: `DWELLING#${args.id}`
+        })
+      };
+    case 'listDwellings':
+      return {
+        operation: 'Query',
+        query: {
+          expression: 'PK = :pk AND begins_with(SK, :sk) AND isDeleted = :nd',
+          expressionValues: util.dynamodb.toMapValues({
+            ':pk': `SUB#${sub}`,
+            ':sk': 'DWELLING#',
+            ':nd': false
+          })
+        }
+      };
+    case 'adminListDwellings':
+      return {
+        operation: 'Scan',
+        filter: {
+          expression:
+            'attribute_exists(PK) AND begins_with(SK, :sk) AND isDeleted = :nd',
+          expressionValues: util.dynamodb.toMapValues({
+            ':sk': 'DWELLING#',
+            ':nd': false
+          })
+        }
+      };
+    case 'createDwelling': {
+      const id = util.autoId();
+      return {
+        operation: 'PutItem',
+        key: util.dynamodb.toMapValues({
+          PK: `SUB#${sub}`,
+          SK: `DWELLING#${id}`
+        }),
+        attributeValues: util.dynamodb.toMapValues({
+          sub_id: sub,
+          name: args.input.name,
+          dwellingType: args.input.dwellingType,
+          address: args.input.address,
+          created: util.time.nowISO8601(),
+          updated: util.time.nowISO8601(),
+          isDeleted: false
+        })
+      };
+    }
+    case 'updateDwelling':
+      return {
+        operation: 'UpdateItem',
+        key: util.dynamodb.toMapValues({
+          PK: `SUB#${sub}`,
+          SK: `DWELLING#${args.id}`
+        }),
+        update: {
+          expression: 'SET #name = :name, #dwellingType = :dwellingType',
+          expressionNames: {
+            '#name': 'name',
+            '#dwellingType': 'dwellingType'
+          },
+          expressionValues: util.dynamodb.toMapValues({
+            ':name': args.input.name,
+            ':dwellingType': args.input.dwellingType
+          })
+        }
+      };
+    case 'deleteDwelling':
+      return {
+        operation: 'UpdateItem',
+        key: util.dynamodb.toMapValues({
+          PK: `SUB#${sub}`,
+          SK: `DWELLING#${args.id}`
+        }),
+        update: {
+          expression: 'SET isDeleted = :deleted',
+          expressionValues: util.dynamodb.toMapValues({ ':deleted': true })
+        }
+      };
+
+    // Room operations
+    case 'getRoom':
+      return {
+        operation: 'GetItem',
+        key: util.dynamodb.toMapValues({
+          PK: `SUB#${sub}`,
+          SK: `ROOM#${args.id}`
+        })
+      };
+    case 'listRooms':
+      return {
+        operation: 'Query',
+        query: {
+          expression: 'PK = :pk AND begins_with(SK, :sk) AND isDeleted = :nd',
+          expressionValues: util.dynamodb.toMapValues({
+            ':pk': `SUB#${sub}`,
+            ':sk': 'ROOM#',
+            ':nd': false
+          })
+        }
+      };
+    case 'createRoom': {
+      const id = util.autoId();
+      return {
+        operation: 'PutItem',
+        key: util.dynamodb.toMapValues({
+          PK: `SUB#${sub}`,
+          SK: `ROOM#${id}`
+        }),
+        attributeValues: util.dynamodb.toMapValues({
+          sub_id: sub,
+          dwelling_id: args.input.dwelling_id,
+          name: args.input.name,
+          roomType: args.input.roomType,
+          created: util.time.nowISO8601(),
+          updated: util.time.nowISO8601(),
+          isDeleted: false
+        })
+      };
+    }
+    case 'updateRoom':
+      return {
+        operation: 'UpdateItem',
+        key: util.dynamodb.toMapValues({
+          PK: `SUB#${sub}`,
+          SK: `ROOM#${args.id}`
+        }),
+        update: {
+          expression: 'SET #name = :name, #roomType = :roomType, #updated = :upd',
+          expressionNames: {
+            '#name': 'name',
+            '#roomType': 'roomType',
+            '#upd': 'updated'
+          },
+          expressionValues: util.dynamodb.toMapValues({
+            ':name': args.input.name,
+            ':roomType': args.input.roomType,
+            ':upd': util.time.nowISO8601()
+          })
+        }
+      };
+    case 'deleteRoom':
+      return {
+        operation: 'UpdateItem',
+        key: util.dynamodb.toMapValues({
+          PK: `SUB#${sub}`,
+          SK: `ROOM#${args.id}`
+        }),
+        update: {
+          expression: 'SET isDeleted = :deleted, updated = :upd',
+          expressionValues: util.dynamodb.toMapValues({
+            ':deleted': true,
+            ':upd': util.time.nowISO8601()
+          })
+        }
+      };
+
+    // Item operations
+    case 'getItem':
+      return {
+        operation: 'GetItem',
+        key: util.dynamodb.toMapValues({
+          PK: `SUB#${sub}`,
+          SK: `ITEM#${args.id}`
+        })
+      };
+    case 'listItems':
+      return {
+        operation: 'Query',
+        query: {
+          expression: 'PK = :pk AND begins_with(SK, :sk) AND isDeleted = :nd',
+          expressionValues: util.dynamodb.toMapValues({
+            ':pk': `SUB#${sub}`,
+            ':sk': 'ITEM#',
+            ':nd': false
+          })
+        }
+      };
+    case 'createItem': {
+      const id = util.autoId();
+      return {
+        operation: 'PutItem',
+        key: util.dynamodb.toMapValues({
+          PK: `SUB#${sub}`,
+          SK: `ITEM#${id}`
+        }),
+        attributeValues: util.dynamodb.toMapValues({
+          sub_id: sub,
+          room_id: args.input.room_id,
+          name: args.input.name,
+          description: args.input.description,
+          details: args.input.details,
+          price: args.input.price,
+          quantity: args.input.quantity,
+          retailer: args.input.retailer,
+          created: util.time.nowISO8601(),
+          updated: util.time.nowISO8601(),
+          isDeleted: false
+        })
+      };
+    }
+    case 'updateItem':
+      return {
+        operation: 'UpdateItem',
+        key: util.dynamodb.toMapValues({
+          PK: `SUB#${sub}`,
+          SK: `ITEM#${args.id}`
+        }),
+        update: {
+          expression:
+            'SET #name = :name, #description = :description, #details = :details, #price = :price, #quantity = :quantity, #retailer = :retailer, #updated = :upd',
+          expressionNames: {
+            '#name': 'name',
+            '#description': 'description',
+            '#details': 'details',
+            '#price': 'price',
+            '#quantity': 'quantity',
+            '#retailer': 'retailer',
+            '#updated': 'updated'
+          },
+          expressionValues: util.dynamodb.toMapValues({
+            ':name': args.input.name,
+            ':description': args.input.description,
+            ':details': args.input.details,
+            ':price': args.input.price,
+            ':quantity': args.input.quantity,
+            ':retailer': args.input.retailer,
+            ':upd': util.time.nowISO8601()
+          })
+        }
+      };
+    case 'deleteItem':
+      return {
+        operation: 'UpdateItem',
+        key: util.dynamodb.toMapValues({
+          PK: `SUB#${sub}`,
+          SK: `ITEM#${args.id}`
+        }),
+        update: {
+          expression: 'SET isDeleted = :deleted, updated = :upd',
+          expressionValues: util.dynamodb.toMapValues({
+            ':deleted': true,
+            ':upd': util.time.nowISO8601()
+          })
+        }
+      };
+    default:
+      return {};
+  }
+}
+
+export function response(ctx) {
+  if (ctx.error) {
+    return util.error(ctx.error.message, ctx.error.type);
+  }
+
+  switch (ctx.info.fieldName) {
+    case 'listDwellings':
+    case 'listRooms':
+    case 'listItems':
+    case 'adminListDwellings':
+      return ctx.result.items || [];
+    case 'deleteDwelling':
+    case 'deleteRoom':
+    case 'deleteItem':
+      return true;
+    default:
+      return ctx.result;
+  }
+}

--- a/src/resources/mapping-templates.yml
+++ b/src/resources/mapping-templates.yml
@@ -1,111 +1,101 @@
-# VTL Resolvers for Dwelling CRUD Operations
 - type: Query
   field: getDwelling
   dataSource: DynamoDBDataSource
-  request: dwelling/getDwelling.request.vtl
-  response: dwelling/getDwelling.response.vtl
+  request: resolvers.js
+  response: resolvers.js
 
 - type: Query
   field: listDwellings
   dataSource: DynamoDBDataSource
-  request: dwelling/listDwellings.request.vtl
-  response: dwelling/listDwellings.response.vtl
+  request: resolvers.js
+  response: resolvers.js
+
+- type: Query
+  field: adminListDwellings
+  dataSource: DynamoDBDataSource
+  request: resolvers.js
+  response: resolvers.js
 
 - type: Mutation
   field: createDwelling
   dataSource: DynamoDBDataSource
-  request: dwelling/createDwelling.request.vtl
-  response: dwelling/createDwelling.response.vtl
+  request: resolvers.js
+  response: resolvers.js
 
 - type: Mutation
   field: updateDwelling
   dataSource: DynamoDBDataSource
-  request: dwelling/updateDwelling.request.vtl
-  response: dwelling/updateDwelling.response.vtl
+  request: resolvers.js
+  response: resolvers.js
 
 - type: Mutation
   field: deleteDwelling
   dataSource: DynamoDBDataSource
-  request: dwelling/deleteDwelling.request.vtl
-  response: dwelling/deleteDwelling.response.vtl
+  request: resolvers.js
+  response: resolvers.js
 
-# VTL Resolvers for Room CRUD Operations
 - type: Query
   field: getRoom
   dataSource: DynamoDBDataSource
-  request: room/getRoom.request.vtl
-  response: room/getRoom.response.vtl
+  request: resolvers.js
+  response: resolvers.js
 
 - type: Query
   field: listRooms
   dataSource: DynamoDBDataSource
-  request: room/listRooms.request.vtl
-  response: room/listRooms.response.vtl
+  request: resolvers.js
+  response: resolvers.js
 
 - type: Mutation
   field: createRoom
   dataSource: DynamoDBDataSource
-  request: room/createRoom.request.vtl
-  response: room/createRoom.response.vtl
+  request: resolvers.js
+  response: resolvers.js
 
 - type: Mutation
   field: updateRoom
   dataSource: DynamoDBDataSource
-  request: room/updateRoom.request.vtl
-  response: room/updateRoom.response.vtl
+  request: resolvers.js
+  response: resolvers.js
 
 - type: Mutation
   field: deleteRoom
   dataSource: DynamoDBDataSource
-  request: room/deleteRoom.request.vtl
-  response: room/deleteRoom.response.vtl
+  request: resolvers.js
+  response: resolvers.js
 
-# VTL Resolvers for Item CRUD Operations
 - type: Query
   field: getItem
   dataSource: DynamoDBDataSource
-  request: item/getItem.request.vtl
-  response: item/getItem.response.vtl
+  request: resolvers.js
+  response: resolvers.js
 
 - type: Query
   field: listItems
   dataSource: DynamoDBDataSource
-  request: item/listItems.request.vtl
-  response: item/listItems.response.vtl
+  request: resolvers.js
+  response: resolvers.js
 
 - type: Mutation
   field: createItem
   dataSource: DynamoDBDataSource
-  request: item/createItem.request.vtl
-  response: item/createItem.response.vtl
+  request: resolvers.js
+  response: resolvers.js
 
 - type: Mutation
   field: updateItem
   dataSource: DynamoDBDataSource
-  request: item/updateItem.request.vtl
-  response: item/updateItem.response.vtl
+  request: resolvers.js
+  response: resolvers.js
 
 - type: Mutation
   field: deleteItem
   dataSource: DynamoDBDataSource
-  request: item/deleteItem.request.vtl
-  response: item/deleteItem.response.vtl
-
-# JavaScript Resolvers
-- type: Query
-  field: getMyDwelling
-  dataSource: DynamoDBDataSource
-  request: dwelling/js-dwelling-resolvers.js
-  response: dwelling/js-dwelling-resolvers.js
+  request: resolvers.js
+  response: resolvers.js
 
 - type: Query
   field: search
   dataSource: DynamoDBDataSource
   request: js-search-resolver.js
   response: js-search-resolver.js
-
-- type: Mutation
-  field: uploadRoomImage
-  dataSource: NoneDataSource
-  request: room/js-room-image-resolver.js
-  response: room/js-room-image-resolver.js


### PR DESCRIPTION
## Summary
- add `src/resolvers/resolvers.js` to handle all DynamoDB CRUD operations
- update mapping templates to point GraphQL fields at the JS resolver
- remove obsolete resolver references

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint configuration missing)*

------
https://chatgpt.com/codex/tasks/task_e_6844b61b2e1883279b97f60ec2e2ecc8