### PR TITLE
Add isDeleted filters to list queries

### DIFF
--- a/src/resolvers/dwelling/listDwellings.request.vtl
+++ b/src/resolvers/dwelling/listDwellings.request.vtl
@@ -2,11 +2,14 @@
   "version": "2018-05-29",
   "operation": "Query",
   "query": {
-    "expression": "PK = :pk AND begins_with(SK, :dwellingPrefix) AND isDeleted = :notDeleted",
+    "expression": "PK = :pk AND begins_with(SK, :dwellingPrefix)",
     "expressionValues": {
       ":pk": { "S": "SUB#$context.identity.sub" },
       ":dwellingPrefix": { "S": "DWELLING#" },
       ":notDeleted": { "BOOL": false }
+    },
+    "filter": {
+      "expression": "isDeleted = :notDeleted"
     }
   }
 }

--- a/src/resolvers/item/listItems.request.vtl
+++ b/src/resolvers/item/listItems.request.vtl
@@ -2,11 +2,14 @@
   "version": "2018-05-29",
   "operation": "Query",
   "query": {
-    "expression": "PK = :pk AND begins_with(SK, :itemPrefix) AND isDeleted = :notDeleted",
+    "expression": "PK = :pk AND begins_with(SK, :itemPrefix)",
     "expressionValues": {
       ":pk": { "S": "SUB#$context.identity.sub" },
       ":itemPrefix": { "S": "ITEM#" },
       ":notDeleted": { "BOOL": false }
+    },
+    "filter": {
+      "expression": "isDeleted = :notDeleted"
     }
   }
 }

--- a/src/resolvers/room/listRooms.request.vtl
+++ b/src/resolvers/room/listRooms.request.vtl
@@ -2,11 +2,14 @@
   "version": "2018-05-29",
   "operation": "Query",
   "query": {
-    "expression": "PK = :pk AND begins_with(SK, :roomPrefix) AND isDeleted = :notDeleted",
+    "expression": "PK = :pk AND begins_with(SK, :roomPrefix)",
     "expressionValues": {
       ":pk": { "S": "SUB#$context.identity.sub" },
       ":roomPrefix": { "S": "ROOM#" },
       ":notDeleted": { "BOOL": false }
+    },
+    "filter": {
+      "expression": "isDeleted = :notDeleted"
     }
   }
 }


### PR DESCRIPTION
## Summary
- switch list query templates to use DynamoDB `filter` instead of embedding isDeleted in key expression

## Testing
- `npm test` *(fails: jest not installed)*
- `npx jest` *(fails: canceled)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_684aaec33d148327b234837f36bf01a1