### PR TITLE
Fix deployment script names in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -207,7 +207,7 @@ If you prefer the stack to create the Cognito pool, uncomment
 Deploy to AWS on the specified stage:
 
 ```bash
-bash deploy.sh
+bash x_deploy.sh-needs-revising
 ```
 
 ## Destroy
@@ -215,7 +215,7 @@ bash deploy.sh
 Destroy the AWS resources on the specified stage:
 
 ```bash
-bash destroy.sh
+bash x_destroy.sh-needs-revising
 ```
 
 ## Postman Collection


### PR DESCRIPTION
## Summary
- fix docs to mention `x_deploy.sh-needs-revising` and `x_destroy.sh-needs-revising`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aaec3dce083279f1344b80c16d8ad